### PR TITLE
Use sha512 instead of sha256, since sha512 is faster on amd64 cpus.

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,14 +1,14 @@
 package auth
 
 import (
-	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/subtle"
 )
 
 // SecureCompare performs a constant time compare of two strings to limit timing attacks.
 func SecureCompare(given string, actual string) bool {
-	givenSha := sha256.Sum256([]byte(given))
-	actualSha := sha256.Sum256([]byte(actual))
+	givenSha := sha512.Sum512([]byte(given))
+	actualSha := sha512.Sum512([]byte(actual))
 
 	return subtle.ConstantTimeCompare(givenSha[:], actualSha[:]) == 1
 }


### PR DESCRIPTION
Ref:
http://crypto.stackexchange.com/a/26340